### PR TITLE
Fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix typo in `assignment` callbaks
+* Alias `assignment` to `assigment` for backwards compatibility
 ## Version 0.2.0
 
 * Don't expose model name on `model`. _(security fix)_

--- a/lib/mini_form/model.rb
+++ b/lib/mini_form/model.rb
@@ -15,11 +15,17 @@ module MiniForm
         extend ClassMethods
 
         define_model_callbacks :update
+        define_model_callbacks :assignment
+        # For backwards compatibility purpose
         define_model_callbacks :assigment
 
         before_update :before_update
         after_update :after_update
 
+        before_assignment :before_assignment
+        after_assignment :after_assignment
+
+        # For backwards compatibility purpose
         before_assigment :before_assigment
         after_assigment :after_assigment
       end
@@ -91,6 +97,14 @@ module MiniForm
     end
 
     def after_update
+      # noop
+    end
+
+    def before_assignment
+      # noop
+    end
+
+    def after_assignment
       # noop
     end
 

--- a/lib/mini_form/model.rb
+++ b/lib/mini_form/model.rb
@@ -40,9 +40,11 @@ module MiniForm
     end
 
     def attributes=(attributes)
-      run_callbacks :assigment do
-        attributes.slice(*self.class.attribute_names).each do |name, value|
-          public_send "#{name}=", value
+      run_callbacks :assignment do
+        run_callbacks :assigment do
+          attributes.slice(*self.class.attribute_names).each do |name, value|
+            public_send "#{name}=", value
+          end
         end
       end
     end

--- a/spec/mini_form_spec.rb
+++ b/spec/mini_form_spec.rb
@@ -248,11 +248,20 @@ module MiniForm
         object.update
       end
 
-      it 'supports assign callbacks' do
+      it 'supports legacy assig callbacks' do
         object = ExampleForUpdate.new
 
         expect(object).to receive(:before_assigment)
         expect(object).to receive(:after_assigment)
+
+        object.update name: 'value'
+      end
+
+      it 'supports assign callbacks' do
+        object = ExampleForUpdate.new
+
+        expect(object).to receive(:before_assignment)
+        expect(object).to receive(:after_assignment)
 
         object.update name: 'value'
       end


### PR DESCRIPTION
Noticed the callbacks added in 0.2.0 are called `before/after_assigment` instead of `before/after_assignment`. This corrects that typo, once released this PR is release, you could get rid of the old code and release another version.