### PR TITLE
Add suport for Rails 6+

### DIFF
--- a/lib/mini_form/errors.rb
+++ b/lib/mini_form/errors.rb
@@ -5,7 +5,8 @@ module MiniForm
     def initialize(object)
       @errors = object.errors
 
-      super "Form validation failed for: #{errors.keys.join(', ')}"
+      arr_obj = errors.respond_to?(:attribute_names) ? errors.attribute_names : errors.keys
+      super "Form validation failed for: #{arr_obj.join(', ')}"
     end
   end
 end

--- a/lib/mini_form/nested_validator.rb
+++ b/lib/mini_form/nested_validator.rb
@@ -5,8 +5,17 @@ module MiniForm
     def validate_each(record, _, relation)
       return if relation.valid?
 
-      relation.errors.each do |name, value|
-        record.errors.add name, value
+      if relation.errors.respond_to?(:attribute_names)
+        # Support for Rails 6.1+ where accessing ActiveModel::Errors as a hash has been
+        # deprecated and the errors array is frozen. For this reason we use the new
+        # method merge!() which appends the errors as NestedErrors to the array. "This is the way."
+        relation.errors.attribute_names.each do |name|
+          record.errors.merge!(relation.errors)
+        end
+      else
+        relation.errors.each do |name, value|
+          record.errors.add name, value
+        end
       end
     end
   end

--- a/lib/mini_form/nested_validator.rb
+++ b/lib/mini_form/nested_validator.rb
@@ -5,17 +5,17 @@ module MiniForm
     def validate_each(record, _, relation)
       return if relation.valid?
 
-      if relation.errors.respond_to?(:attribute_names)
-        # Support for Rails 6.1+ where accessing ActiveModel::Errors as a hash has been
+      if record.errors.respond_to?(:merge!)
+        # Rails 6.1+ where accessing ActiveModel::Errors as a hash has been
         # deprecated and the errors array is frozen. For this reason we use the new
         # method merge!() which appends the errors as NestedErrors to the array. "This is the way."
-        relation.errors.attribute_names.each do |name|
-          record.errors.merge!(relation.errors)
-        end
-      else
-        relation.errors.each do |name, value|
-          record.errors.add name, value
-        end
+        record.errors.merge!(relation.errors)
+        return
+      end
+
+      # Rails < 6.1
+      relation.errors.each do |name, value|
+        record.errors.add name, value
       end
     end
   end

--- a/spec/mini_form_spec.rb
+++ b/spec/mini_form_spec.rb
@@ -51,6 +51,10 @@ module MiniForm
         expect(value).to eq(expected_value), message
       end
 
+      def assert_respond_to(klass, method, message = nil)
+        expect(klass).to respond_to(method), message
+      end
+
       ActiveModel::Lint::Tests.public_instance_methods.map(&:to_s).grep(/^test/).each do |method|
         example(method.gsub('_', ' ')) { send method }
       end


### PR DESCRIPTION
Accessing errors as hash in Rails 6.1 is deprecated. It is an error array
now that contains full-blown Error objects, so:

- use errors.attribute_names to get the error keys (instead of Hash.keys)
- to append errors to another error array use merge! which adds them as NestedErrors.
- specs were failing due to a missing method, so added assert_respond_to()